### PR TITLE
create stream from iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const stream = require('stream');
 const AsyncIter = require('./asyncIter');
+const wrapIterator = require('./wrap-iterator');
 
 exports.Writable = stream.Writable;
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ class Readable extends stream.Readable {
   [Symbol.asyncIterator]() {
     return new AsyncIter(this);
   }
+  wrapIterator(iterator) {
+    return wrapIterator(iterator, this);
+  }
 }
 exports.Readable = Readable;
 

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "babel-plugin-transform-async-generator-functions": "^6.17.0",
     "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-register": "^6.18.0"
+  },
+  "dependencies": {
+    "tape": "^4.6.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const stream = require('../');
-
+const test = require('tape');
 class MyStream extends stream.Readable {
   constructor() {
     super({
@@ -9,17 +9,65 @@ class MyStream extends stream.Readable {
   }
   _read() {
     this.push(++this.times);
-    if (this.times > 10) {
+    if (this.times >= 10) {
       this.push(null);
     }
   }
 }
 
 
-async function test() {
+async function test1(t) {
+  let i = 1;
   for await (let x of new MyStream()) {
-    console.log(x);
+    t.equals(i++, x);
   }
 }
 
-test().then(()=>console.log('done'), e=>{console.log(e)});
+test('iterate stream', t=>{
+  t.plan(10);
+  test1(t);
+});
+test('stream iterator', t=>{
+  t.plan(10);
+  test2(t);
+})
+test('stream sync iterator', t=>{
+  t.plan(10);
+  test3(t);
+})
+async function increment (num) {
+  return num + 1;
+}
+
+async function * asyncTester(num) {
+  var i = num;
+  while(i < 10) {
+    yield i;
+    i = await increment(i);
+  }
+  return i;
+}
+function test2(t) {
+  var i = 1;
+  var a = new stream.Readable({objectMode: true});
+  a.wrapIterator(asyncTester(1));
+  a.pipe(new stream.Writable({
+    objectMode: true,
+    write(chunk, _, next) {
+      t.equals(i++, chunk);
+      next();
+    }
+   }))
+}
+function test3(t) {
+  var i = 1;
+  var a = new stream.Readable({objectMode: true});
+  a.wrapIterator([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  a.pipe(new stream.Writable({
+    objectMode: true,
+    write(chunk, _, next) {
+      t.equals(i++, chunk);
+      next();
+    }
+   }))
+}

--- a/wrap-iterator.js
+++ b/wrap-iterator.js
@@ -26,6 +26,7 @@ const wrapAsyncIterator = (iterator, stream) =>{
       inProgress = false;
     })
   }
+  return stream;
 }
 
 const wrapIterator = (iterator, stream) =>{
@@ -45,6 +46,7 @@ const wrapIterator = (iterator, stream) =>{
       }
     }
   }
+  return stream;
 }
 
 module.exports = (iterator, stream) => {

--- a/wrap-iterator.js
+++ b/wrap-iterator.js
@@ -1,0 +1,57 @@
+
+
+const wrapAsyncIterator = (iterator, stream) =>{
+  var inProgress = false;
+  var done = false;
+  let write = next => {
+    if (next.done) {
+      if (typeof next.value !== 'undefined') {
+        stream.push(next.value);
+      }
+      stream.push(null);
+      done = true;
+      return;
+    }
+    let ret = stream.push(next.value);
+    if (ret) {
+      return iterator.next().then(write);
+    }
+  }
+  stream._read = function () {
+    if (inProgress || done) {
+      return;
+    }
+    inProgress = true;
+    iterator.next().then(write).then(()=>{
+      inProgress = false;
+    })
+  }
+}
+
+const wrapIterator = (iterator, stream) =>{
+  stream._read = function () {
+    while(true) {
+      let next = iterator.next();
+      if (next.done) {
+        if (typeof next.value !== 'undefined') {
+          this.push(next.value);
+        }
+        this.push(null);
+        return;
+      }
+      let ret = this.push(next.value);
+      if (!ret) {
+        return;
+      }
+    }
+  }
+}
+
+module.exports = (iterator, stream) => {
+  if (Symbol.asyncIterator && typeof iterator[Symbol.asyncIterator] === 'function') {
+    return wrapAsyncIterator(iterator[Symbol.asyncIterator](), stream);
+  }
+  if (Symbol.iterator && typeof iterator[Symbol.iterator] === 'function') {
+    return wrapIterator(iterator[Symbol.iterator](), stream);
+  }
+};


### PR DESCRIPTION
from tc39/proposal-async-iteration#74, adds a wrapIterator method on the prototype similar to wrap, wonder if it would also make sense to add a similar static method on the constructor, maybe taking a second argument for constructor options